### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/JoshuaWillis/fb999b66-28de-457b-b603-addef2915db6/3fb84f0c-049e-48e2-bdce-997d616da14a/_apis/work/boardbadge/62e49e1c-bb40-4305-b014-54544339316b)](https://dev.azure.com/JoshuaWillis/fb999b66-28de-457b-b603-addef2915db6/_boards/board/t/3fb84f0c-049e-48e2-bdce-997d616da14a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/JoshuaWillis/fb999b66-28de-457b-b603-addef2915db6/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.